### PR TITLE
TallyGameAnalysis: ignore skipped games

### DIFF
--- a/analysis/util/TallyGameAnalytics.py
+++ b/analysis/util/TallyGameAnalytics.py
@@ -47,6 +47,8 @@ class TallyGameAnalytics:
         )
 
     def add_glicko2_analytics(self, result: Glicko2Analytics) -> None:
+        if result.skipped:
+            return
         if result.black_deviation > 160 or result.white_deviation > 160:
             self.games_ignored += 1
             return


### PR DESCRIPTION
We shouldn't include skipped games in analysis. Right now they count as 30k games.