### PR TITLE
implement glicko2 according to glickman's description. Plus two variants

### DIFF
--- a/analysis/analyze_glicko2_glickman_weekly_window.py
+++ b/analysis/analyze_glicko2_glickman_weekly_window.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env -S PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=..:. pypy3
+
+from analysis.util import (
+    Glicko2Analytics,
+    InMemoryStorage,
+    GameData,
+    TallyGameAnalytics,
+    cli,
+    config,
+    get_handicap_adjustment,
+    rating_to_rank,
+)
+from goratings.interfaces import GameRecord, RatingSystem, Storage
+from goratings.math.glicko2 import Glicko2Entry, glicko2_update
+
+window_width = (7 * 24 * 60 * 60)
+no_games_window_witdh = window_width
+
+class DailyWindows(RatingSystem):
+    _storage: Storage
+
+    def __init__(self, storage: Storage) -> None:
+        self._storage = storage
+
+    def process_game(self, game: GameRecord) -> Glicko2Analytics:
+        ## Only count the first timeout in correspondence games as a ranked loss
+        if game.timeout and game.speed == 3: # correspondence timeout
+            player_that_timed_out = game.black_id if game.black_id != game.winner_id else game.white_id
+            skip = self._storage.get_timeout_flag(game.black_id) or self._storage.get_timeout_flag(game.white_id)
+            self._storage.set_timeout_flag(player_that_timed_out, True)
+            if skip:
+                return Glicko2Analytics(skipped=True, game=game)
+        if game.speed == 3: # clear corr. timeout flags
+            self._storage.set_timeout_flag(game.black_id, True)
+            self._storage.set_timeout_flag(game.white_id, True)
+
+        ## read base rating (last rating before the current rating period)
+        window = (int(game.ended) // window_width) * window_width
+        black_base = self._storage.get_first_rating_older_than(game.black_id, window).copy()
+        white_base = self._storage.get_first_rating_older_than(game.white_id, window).copy()
+
+        ## since we do not update deviation in periods without games, we have to do update it now if there are empty periods size the base rating was calclulated
+        black_base_time = self._storage.get_first_timestamp_older_than(game.black_id, window)
+        white_base_time = self._storage.get_first_timestamp_older_than(game.white_id, window)
+        
+        if black_base_time is not None:
+            black_base.expand_deviation_because_no_games_played(int((game.ended - black_base_time) / no_games_window_witdh))
+        if white_base_time is not None:
+            white_base.expand_deviation_because_no_games_played(int((game.ended - white_base_time) / no_games_window_witdh))
+
+        black_cur = black_base.copy()
+        white_cur = white_base.copy()
+
+        ## store games in the match history
+        self._storage.add_match_history(game.black_id, game.ended, (game, white_base))
+        self._storage.add_match_history(game.white_id, game.ended, (game, black_base))
+
+        ## update ratings
+        updated_black = glicko2_update(
+            black_base,
+            [
+                (
+                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    past_game.winner_id == past_game.black_id
+                )
+                for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
+                    game.black_id, window
+                )
+            ]
+        )
+
+        updated_white = glicko2_update(
+            white_base,
+            [
+                (
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    past_game.winner_id == past_game.white_id
+                )
+                for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
+                    game.white_id, window
+                )
+            ]
+        )
+
+        self._storage.set(game.black_id, updated_black)
+        self._storage.set(game.white_id, updated_white)
+        self._storage.add_rating_history(game.black_id, game.ended, updated_black)
+        self._storage.add_rating_history(game.white_id, game.ended, updated_white)
+
+        return Glicko2Analytics(
+            skipped=False,
+            game=game,
+            expected_win_rate=black_cur.expected_win_probability(
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+            ),
+            black_rating=black_cur.rating,
+            white_rating=white_cur.rating,
+            black_deviation=black_cur.deviation,
+            white_deviation=white_cur.deviation,
+            black_rank=rating_to_rank(black_cur.rating),
+            white_rank=rating_to_rank(white_cur.rating),
+            black_updated_rating=updated_black.rating,
+            white_updated_rating=updated_white.rating,
+        )
+
+
+
+# Run
+config(cli.parse_args(), name="glicko2-glickman-1-week-window")
+ogs_game_data = GameData()
+storage = InMemoryStorage(Glicko2Entry)
+engine = DailyWindows(storage)
+tally = TallyGameAnalytics(storage)
+
+for game in ogs_game_data:
+    analytics = engine.process_game(game)
+    tally.add_glicko2_analytics(analytics)
+
+tally.print()

--- a/analysis/analyze_glicko2_weekly_window_no_unxepected_changes.py
+++ b/analysis/analyze_glicko2_weekly_window_no_unxepected_changes.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env -S PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=..:. pypy3
+
+from analysis.util import (
+    Glicko2Analytics,
+    InMemoryStorage,
+    GameData,
+    TallyGameAnalytics,
+    cli,
+    config,
+    get_handicap_adjustment,
+    rating_to_rank,
+)
+from goratings.interfaces import GameRecord, RatingSystem, Storage
+from goratings.math.glicko2 import Glicko2Entry, glicko2_update
+
+window_width = (7 * 24 * 60 * 60)
+no_games_window_witdh = window_width
+
+class DailyWindows(RatingSystem):
+    _storage: Storage
+
+    def __init__(self, storage: Storage) -> None:
+        self._storage = storage
+
+    def process_game(self, game: GameRecord) -> Glicko2Analytics:
+        ## Only count the first timeout in correspondence games as a ranked loss
+        if game.timeout and game.speed == 3: # correspondence timeout
+            player_that_timed_out = game.black_id if game.black_id != game.winner_id else game.white_id
+            skip = self._storage.get_timeout_flag(game.black_id) or self._storage.get_timeout_flag(game.white_id)
+            self._storage.set_timeout_flag(player_that_timed_out, True)
+            if skip:
+                return Glicko2Analytics(skipped=True, game=game)
+        if game.speed == 3: # clear corr. timeout flags
+            self._storage.set_timeout_flag(game.black_id, True)
+            self._storage.set_timeout_flag(game.white_id, True)
+
+        ## read base rating (last rating before the current rating period)
+        window = (int(game.ended) // window_width) * window_width
+        black_base = self._storage.get_first_rating_older_than(game.black_id, window).copy()
+        white_base = self._storage.get_first_rating_older_than(game.white_id, window).copy()
+
+        ## since we do not update deviation in periods without games, we have to do update it now if there are empty periods size the base rating was calclulated
+        black_base_time = self._storage.get_first_timestamp_older_than(game.black_id, window)
+        white_base_time = self._storage.get_first_timestamp_older_than(game.white_id, window)
+        
+        if black_base_time is not None:
+            black_base.expand_deviation_because_no_games_played(int((game.ended - black_base_time) / no_games_window_witdh))
+        if white_base_time is not None:
+            white_base.expand_deviation_because_no_games_played(int((game.ended - white_base_time) / no_games_window_witdh))
+
+        ## store games in the match history
+        self._storage.add_match_history(game.black_id, game.ended, (game, white_base))
+        self._storage.add_match_history(game.white_id, game.ended, (game, black_base))
+
+        ## update ratings
+        updated_black = glicko2_update(
+            black_base,
+            [
+                (
+                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    past_game.winner_id == past_game.black_id
+                )
+                for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
+                    game.black_id, window
+                )
+            ]
+        )
+
+        updated_white = glicko2_update(
+            white_base,
+            [
+                (
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    past_game.winner_id == past_game.white_id
+                )
+                for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
+                    game.white_id, window
+                )
+            ]
+        )
+
+        # do not decrease rating if player won or increase if she lost
+        # users complain when their rating drops after they won a game, even if it is only by a few points. This happens
+        # regular since the deviation becomes lower with each game played in a period.
+        # Here we accept the rating system to be slightly less accurate for the sake of user experience. Since we use
+        # the base rating of  both players when updating the ratings, this only affects future rating updates if this
+        # game happens to be the last game in the rating period of the affected player.
+        black_cur = self._storage.get(game.black_id).copy()
+        white_cur = self._storage.get(game.white_id).copy()
+        if (game.winner_id == game.black_id and updated_black.rating - black_cur.rating < 0) or \
+            (game.winner_id != game.black_id and updated_black.rating - black_cur.rating > 0):
+            updated_black = Glicko2Entry(rating=black_cur.rating, deviation=updated_black.deviation, volatility=updated_black.volatility)
+        if (game.winner_id == game.white_id and updated_white.rating - white_cur.rating < 0) or \
+            (game.winner_id != game.white_id and updated_white.rating - white_cur.rating > 0):
+            updated_white = Glicko2Entry(rating=white_cur.rating, deviation=updated_white.deviation, volatility=updated_white.volatility)
+
+        self._storage.set(game.black_id, updated_black)
+        self._storage.set(game.white_id, updated_white)
+        self._storage.add_rating_history(game.black_id, game.ended, updated_black)
+        self._storage.add_rating_history(game.white_id, game.ended, updated_white)
+
+        return Glicko2Analytics(
+            skipped=False,
+            game=game,
+            expected_win_rate=black_cur.expected_win_probability(
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+            ),
+            black_rating=black_cur.rating,
+            white_rating=white_cur.rating,
+            black_deviation=black_cur.deviation,
+            white_deviation=white_cur.deviation,
+            black_rank=rating_to_rank(black_cur.rating),
+            white_rank=rating_to_rank(white_cur.rating),
+            black_updated_rating=updated_black.rating,
+            white_updated_rating=updated_white.rating,
+        )
+
+
+
+# Run
+config(cli.parse_args(), name="glicko2-glickman-1-week-window")
+ogs_game_data = GameData()
+storage = InMemoryStorage(Glicko2Entry)
+engine = DailyWindows(storage)
+tally = TallyGameAnalytics(storage)
+
+for game in ogs_game_data:
+    analytics = engine.process_game(game)
+    tally.add_glicko2_analytics(analytics)
+
+tally.print()

--- a/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
+++ b/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env -S PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=..:. pypy3
+
+from analysis.util import (
+    Glicko2Analytics,
+    InMemoryStorage,
+    GameData,
+    TallyGameAnalytics,
+    cli,
+    config,
+    get_handicap_adjustment,
+    rating_to_rank,
+)
+from goratings.interfaces import GameRecord, RatingSystem, Storage
+from goratings.math.glicko2 import Glicko2Entry, glicko2_update
+
+window_width = (7 * 24 * 60 * 60)
+no_games_window_witdh = window_width
+
+rating_change_limit = 1.0
+
+class DailyWindows(RatingSystem):
+    _storage: Storage
+
+    def __init__(self, storage: Storage) -> None:
+        self._storage = storage
+
+    def process_game(self, game: GameRecord) -> Glicko2Analytics:
+        ## Only count the first timeout in correspondence games as a ranked loss
+        if game.timeout and game.speed == 3: # correspondence timeout
+            player_that_timed_out = game.black_id if game.black_id != game.winner_id else game.white_id
+            skip = self._storage.get_timeout_flag(game.black_id) or self._storage.get_timeout_flag(game.white_id)
+            self._storage.set_timeout_flag(player_that_timed_out, True)
+            if skip:
+                return Glicko2Analytics(skipped=True, game=game)
+        if game.speed == 3: # clear corr. timeout flags
+            self._storage.set_timeout_flag(game.black_id, True)
+            self._storage.set_timeout_flag(game.white_id, True)
+
+        ## read base rating (last rating before the current rating period)
+        window = (int(game.ended) // window_width) * window_width
+        black_base = self._storage.get_first_rating_older_than(game.black_id, window).copy()
+        white_base = self._storage.get_first_rating_older_than(game.white_id, window).copy()
+
+        ## since we do not update deviation in periods without games, we have to do update it now if there are empty periods size the base rating was calclulated
+        black_base_time = self._storage.get_first_timestamp_older_than(game.black_id, window)
+        white_base_time = self._storage.get_first_timestamp_older_than(game.white_id, window)
+        
+        if black_base_time is not None:
+            black_base.expand_deviation_because_no_games_played(int((game.ended - black_base_time) / no_games_window_witdh))
+        if white_base_time is not None:
+            white_base.expand_deviation_because_no_games_played(int((game.ended - white_base_time) / no_games_window_witdh))
+
+        black_cur = black_base.copy()
+        white_cur = white_base.copy()
+
+        ## store games in the match history
+        self._storage.add_match_history(game.black_id, game.ended, (game, white_base))
+        self._storage.add_match_history(game.white_id, game.ended, (game, black_base))
+
+        ## update ratings
+        updated_black = glicko2_update(
+            black_base,
+            [
+                (
+                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    past_game.winner_id == past_game.black_id
+                )
+                for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
+                    game.black_id, window
+                )
+            ]
+        )
+
+        updated_white = glicko2_update(
+            white_base,
+            [
+                (
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    past_game.winner_id == past_game.white_id
+                )
+                for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
+                    game.white_id, window
+                )
+            ]
+        )
+
+        ## limit rating changes by base RD * num games
+        # glicko2 is desinged to update ratings based on full rating periods. There is a natural lower bound of the RD 
+        # depending on the number of games in the period. If there are fewer games in a period the RD is higher which
+        # results in bigger changes per game.
+        # We calculate imemdiate ratings each time a game ends. So after a new rating period started the game pool is
+        # empty and we get a RD which can be much higher than the RD at the end of the last period, making the first
+        # rating update in a period way stronger than it should be. This will be corrected by later rating updates, but
+        # as we show this rating in UI and use it for match making, we see the over adjusted rating.
+        # Here we limit the change of the rating early in a period by the deviation of the base rating multiplied by the
+        # number of games played in the current periode. (This would be the maximum rating change if the updated
+        # deviation would be the base rating. With the player playing more games, this limit will affect the rating
+        # update less.)
+        black_num_games: int = len(self._storage.get_matches_newer_or_equal_to(
+                    game.black_id, window
+                ))
+        white_num_games: int = len(self._storage.get_matches_newer_or_equal_to(
+                    game.white_id, window
+                ))
+
+        updated_black.rating = min(black_base.rating + rating_change_limit * black_base.deviation * black_num_games,
+                            max(black_base.rating - rating_change_limit * black_base.deviation * black_num_games,
+                                updated_black.rating))
+        updated_white.rating = min(white_base.rating + rating_change_limit * white_base.deviation * white_num_games,
+                            max(white_base.rating - rating_change_limit * white_base.deviation * white_num_games,
+                                updated_white.rating))
+
+        self._storage.set(game.black_id, updated_black)
+        self._storage.set(game.white_id, updated_white)
+        self._storage.add_rating_history(game.black_id, game.ended, updated_black)
+        self._storage.add_rating_history(game.white_id, game.ended, updated_white)
+
+        return Glicko2Analytics(
+            skipped=False,
+            game=game,
+            expected_win_rate=black_cur.expected_win_probability(
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+            ),
+            black_rating=black_cur.rating,
+            white_rating=white_cur.rating,
+            black_deviation=black_cur.deviation,
+            white_deviation=white_cur.deviation,
+            black_rank=rating_to_rank(black_cur.rating),
+            white_rank=rating_to_rank(white_cur.rating),
+            black_updated_rating=updated_black.rating,
+            white_updated_rating=updated_white.rating,
+        )
+
+
+
+# Run
+config(cli.parse_args(), name="glicko2-glickman-1-week-window")
+ogs_game_data = GameData()
+storage = InMemoryStorage(Glicko2Entry)
+engine = DailyWindows(storage)
+tally = TallyGameAnalytics(storage)
+
+for game in ogs_game_data:
+    analytics = engine.process_game(game)
+    tally.add_glicko2_analytics(analytics)
+
+tally.print()


### PR DESCRIPTION
Implement Glicko2 closer to Prof. Glickmans description. 

The original Glicko2 description has 2 major differences to the "glicko2_daily_window" implementation already in this repo:
1)  If a player has not played any games in a rating period, the deviation is increased accordingly.
2)  The base rating of opponents is used instead of their current rating. 

Additionally, there are 2 additional proposals:
1) one suppresses unexpected rating changes (rating drop after a win or rating gain after a loss)
    Because there is always someone to complain and glicko2 has many of those unexpected changes when calculating immediate updates. With increasing window width, the rate of unexpected changes seems to even increase.
2) the other throttles the rating changes at the start of a rating window. 
    As the deviation for a rating period with just one game is higher than the deviation for a period with many games, the first game in a rating period will disproportionally change the rating. This is compensated by later rating updates, but at the start of a rating period, the player's rating will be off just because there is only one game in the rating period so far. Since glicko2 is supposed to run just ones at the end of a rating period (without partial updates within a rating period), the gllicko2 algorithm does not account for partial periods. 

Stats (with --min-rd 0.0):
| Algorithm name |   all   |    h0   |    h1   |    h2   | rating changed in the wrong direction |
|:---------------|--------:|--------:|--------:|--------:|---------------------------------------:
| glickman 7 days | 0.69153 | 0.69056 | 0.69502 | 0.69835 | 33.38552% |
| no unexpected rating changes 7 days | 0.69123 | 0.69035 | 0.69380 | 0.69589 | 0.00000% |
| limited rating change | 0.69153 | 0.69057 | 0.69508 | 0.69842 | 33.39348% |
||||||
| glickman 1 day | 0.69157 | 0.69068 | 0.69448 | 0.69570 | 24.32147% |
| glickman 14 days | 0.69214 | 0.69126 | 0.69606 | 0.69854 | 35.70914% |
| glickman 28 days | 0.69270 | 0.69189 | 0.69619 | 0.69900 | 37.95983% |
| glickman 56 days | 0.69214 | 0.69126 | 0.69606 | 0.69854 | 35.70914% |
