### PR TITLE
Incorporate komi into ratings (particularly for small boards)

### DIFF
--- a/analysis/analyze_glicko2_daily_windows.py
+++ b/analysis/analyze_glicko2_daily_windows.py
@@ -53,7 +53,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id  else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.black_id  else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == game.black_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -66,7 +68,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == game.white_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -84,7 +88,9 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black_cur.rating,
             white_rating=white_cur.rating,

--- a/analysis/analyze_glicko2_glickman_weekly_window.py
+++ b/analysis/analyze_glicko2_glickman_weekly_window.py
@@ -60,7 +60,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.black_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -73,7 +75,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.white_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -91,7 +95,9 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black_cur.rating,
             white_rating=white_cur.rating,

--- a/analysis/analyze_glicko2_one_game_at_a_time.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time.py
@@ -8,6 +8,7 @@ from analysis.util import (
     cli,
     config,
     get_handicap_adjustment,
+    get_handicap_rank_difference,
     rating_to_rank,
     rank_to_rating,
 )
@@ -48,6 +49,15 @@ class OneGameAtATime(RatingSystem):
 
         black = self._storage.get(game.black_id)
         white = self._storage.get(game.white_id)
+
+        # Skip games with effective handicap > 9.
+        #
+        # FIXME: Should be in all analysis scripts, not just this one. Can we
+        # centralize somehow?
+        if get_handicap_rank_difference(
+                handicap=game.handicap, size=game.size,
+                komi=game.komi, rules=game.rules) > 9:
+            return Glicko2Analytics(skipped=True, game=game)
 
         updated_black = glicko2_update(
             black,

--- a/analysis/analyze_glicko2_one_game_at_a_time.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time.py
@@ -49,12 +49,14 @@ class OneGameAtATime(RatingSystem):
         black = self._storage.get(game.black_id)
         white = self._storage.get(game.white_id)
 
-
         updated_black = glicko2_update(
             black,
             [
                 (
-                    white.copy(-get_handicap_adjustment(white.rating, game.handicap)),
+                    white.copy(-get_handicap_adjustment(white.rating, game.handicap,
+                                                        komi=game.komi, size=game.size,
+                                                        rules=game.rules,
+                            )),
                     game.winner_id == game.black_id,
                 )
             ],
@@ -64,7 +66,10 @@ class OneGameAtATime(RatingSystem):
             white,
             [
                 (
-                    black.copy(get_handicap_adjustment(black.rating, game.handicap)),
+                    black.copy(get_handicap_adjustment(black.rating, game.handicap,
+                                                       komi=game.komi, size=game.size,
+                                                       rules=game.rules,
+                            )),
                     game.winner_id == game.white_id,
                 )
             ],
@@ -79,7 +84,10 @@ class OneGameAtATime(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black.expected_win_probability(
-                white, get_handicap_adjustment(black.rating, game.handicap), ignore_g=True
+                white, get_handicap_adjustment(black.rating, game.handicap,
+                                               komi=game.komi, size=game.size,
+                                               rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black.rating,
             white_rating=white.rating,

--- a/analysis/analyze_glicko2_one_game_at_a_time_rating_grid.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time_rating_grid.py
@@ -70,7 +70,9 @@ class OneGameAtATimeRatingGrid(RatingSystem):
                     black,
                     [
                         (
-                            src_white.copy(-get_handicap_adjustment(src_white.rating, game.handicap)),
+                            src_white.copy(-get_handicap_adjustment(src_white.rating, game.handicap,
+                                    komi=game.komi, size=game.size, rules=game.rules,
+                                    )),
                             game.winner_id == game.black_id,
                         )
                     ],
@@ -80,7 +82,9 @@ class OneGameAtATimeRatingGrid(RatingSystem):
                     white,
                     [
                         (
-                            src_black.copy(get_handicap_adjustment(src_black.rating, game.handicap)),
+                            src_black.copy(get_handicap_adjustment(src_black.rating, game.handicap,
+                                    komi=game.komi, size=game.size, rules=game.rules,
+                                    )),
                             game.winner_id == game.white_id,
                         )
                     ],
@@ -96,7 +100,9 @@ class OneGameAtATimeRatingGrid(RatingSystem):
                     skipped=False,
                     game=game,
                     expected_win_rate=black.expected_win_probability(
-                        white, get_handicap_adjustment(black.rating, game.handicap), ignore_g=True
+                        white, get_handicap_adjustment(black.rating, game.handicap,
+                            komi=game.komi, size=game.size, rules=game.rules,
+                            ), ignore_g=True
                     ),
                     black_rating=black.rating,
                     white_rating=white.rating,

--- a/analysis/analyze_glicko2_weekly_window_no_unxepected_changes.py
+++ b/analysis/analyze_glicko2_weekly_window_no_unxepected_changes.py
@@ -57,7 +57,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.black_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -70,7 +72,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.white_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -103,7 +107,9 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black_cur.rating,
             white_rating=white_cur.rating,

--- a/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
+++ b/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
@@ -62,7 +62,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.black_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -75,7 +77,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.white_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -119,7 +123,9 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black_cur.rating,
             white_rating=white_cur.rating,

--- a/analysis/analyze_gor.py
+++ b/analysis/analyze_gor.py
@@ -52,15 +52,19 @@ class OneGameAtATime(RatingSystem):
 
 
         updated_black = gor_update(
-            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap)),
-            #white.with_handicap(-get_handicap_adjustment(white.rating, game.handicap)),
+            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    )),
+            #white.with_handicap(-get_handicap_adjustment(white.rating, game.handicap, ...)),
             white,
             1 if game.winner_id == game.black_id else 0,
         )
 
         updated_white = gor_update(
             white,
-            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap)),
+            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    )),
             1 if game.winner_id == game.white_id else 0,
         )
 
@@ -73,8 +77,10 @@ class OneGameAtATime(RatingSystem):
         return GorAnalytics(
             skipped=False,
             game=game,
-            expected_win_rate=black.with_handicap(get_handicap_adjustment(white.rating, game.handicap)).expected_win_probability(
-                #white.copy(-get_handicap_adjustment(white.rating, game.handicap))
+            expected_win_rate=black.with_handicap(get_handicap_adjustment(white.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    )).expected_win_probability(
+                #white.copy(-get_handicap_adjustment(white.rating, game.handicap, ...))
                 white
             ),
             black_rating=black.rating,

--- a/analysis/util/RatingMath.py
+++ b/analysis/util/RatingMath.py
@@ -8,6 +8,7 @@ __all__ = [
     "rank_to_rating",
     "rating_to_rank",
     "get_handicap_adjustment",
+    "get_handicap_rank_difference",
     "rating_config",
     "set_optimizer_rating_points",
     "set_exhaustive_log_parameters",

--- a/analysis/util/TallyGameAnalytics.py
+++ b/analysis/util/TallyGameAnalytics.py
@@ -142,16 +142,16 @@ class TallyGameAnalytics:
 
     def print_compact_stats(self) -> None:
         prediction = (
-            self.prediction_cost[19][ALL][ALL][ALL] / max(1, self.count[19][ALL][ALL][ALL])
+            self.prediction_cost[ALL][ALL][ALL][ALL] / max(1, self.count[ALL][ALL][ALL][ALL])
         )
         prediction_h0 = (
-            self.prediction_cost[19][ALL][ALL][0] / max(1, self.count[19][ALL][ALL][0])
+            self.prediction_cost[ALL][ALL][ALL][0] / max(1, self.count[ALL][ALL][ALL][0])
         )
         prediction_h1 = (
-            self.prediction_cost[19][ALL][ALL][1] / max(1, self.count[19][ALL][ALL][1])
+            self.prediction_cost[ALL][ALL][ALL][1] / max(1, self.count[ALL][ALL][ALL][1])
         )
         prediction_h2 = (
-            self.prediction_cost[19][ALL][ALL][2] / max(1, self.count[19][ALL][ALL][2])
+            self.prediction_cost[ALL][ALL][ALL][2] / max(1, self.count[ALL][ALL][ALL][2])
         )
 
         #unexp_change = (

--- a/analysis/util/TallyGameAnalytics.py
+++ b/analysis/util/TallyGameAnalytics.py
@@ -17,7 +17,7 @@ from .GameData import datasets_used
 from .Glicko2Analytics import Glicko2Analytics
 from .GorAnalytics import GorAnalytics
 from .InMemoryStorage import InMemoryStorage
-from .RatingMath import rating_config, rating_to_rank
+from .RatingMath import rating_config, rating_to_rank, get_handicap_rank_difference
 from .EGFGameData import EGFGameData
 from .AGAGameData import AGAGameData
 
@@ -73,7 +73,10 @@ class TallyGameAnalytics:
             self.games_ignored += 1
             return
 
-        if abs(result.black_rank + result.game.handicap - result.white_rank) > 1:
+        handicap_rank_difference = get_handicap_rank_difference(
+                handicap=result.game.handicap, size=result.game.size,
+                komi=result.game.komi, rules=result.game.rules)
+        if abs(result.black_rank + handicap_rank_difference - result.white_rank) > 1:
             self.games_ignored += 1
             return
 
@@ -89,7 +92,7 @@ class TallyGameAnalytics:
                 ]:
                     for handicap in [ALL, result.game.handicap]:
                         if isinstance(rank, int) or isinstance(rank, str):  # this is just to make mypy happy
-                            if abs(result.black_rank + result.game.handicap - result.white_rank) <= 1:
+                            if abs(result.black_rank + handicap_rank_difference - result.white_rank) <= 1:
                                 self.count_black_wins[size][speed][rank][handicap] += 1
                                 if black_won:
                                     self.black_wins[size][speed][rank][handicap] += 1
@@ -110,7 +113,10 @@ class TallyGameAnalytics:
             self.games_ignored += 1
             return
 
-        if abs(result.black_rank + result.game.handicap - result.white_rank) > 1:
+        handicap_rank_difference = get_handicap_rank_difference(
+                handicap=result.game.handicap, size=result.game.size,
+                komi=result.game.komi, rules=result.game.rules)
+        if abs(result.black_rank + handicap_rank_difference - result.white_rank) > 1:
             self.games_ignored += 1
             return
 

--- a/analysis/util/__init__.py
+++ b/analysis/util/__init__.py
@@ -6,7 +6,7 @@ from .Glicko2Analytics import Glicko2Analytics
 from .GorAnalytics import GorAnalytics
 from .InMemoryStorage import InMemoryStorage
 from .OGSGameData import OGSGameData
-from .RatingMath import get_handicap_adjustment, rank_to_rating, rating_to_rank, set_optimizer_rating_points, set_exhaustive_log_parameters
+from .RatingMath import get_handicap_adjustment, get_handicap_rank_difference, rank_to_rating, rating_to_rank, set_optimizer_rating_points, set_exhaustive_log_parameters
 from .TallyGameAnalytics import TallyGameAnalytics, num2rank
 
 __all__ = [
@@ -23,6 +23,7 @@ __all__ = [
     "rating_to_rank",
     "rank_to_rating",
     "get_handicap_adjustment",
+    "get_handicap_rank_difference",
     "configure_rating_to_rank",
     "num2rank",
     "set_optimizer_rating_points",


### PR DESCRIPTION
Add komi integration to the ratings math. This path can be turned on using:
    
- `--compute-handicap-via-komi-small` for 9x9 and 13x13 boards
- `--compute-handicap-via-komi-19x19` for 19x19 boards

This requires passing extra info to `get_handicap_adjustment`:

- komi
- size
- rules

Unfortunately the rules don't seem to be in the database (starting out by hardcoding to `"japanese"`). Maybe we can fix that?

Relates to #45