### PR TITLE
Infer komi for AGA and EGF games and read rules for OGS data

### DIFF
--- a/analysis/util/AGAGameData.py
+++ b/analysis/util/AGAGameData.py
@@ -69,8 +69,10 @@ class AGAGameData:
                 )
                 sys.stdout.flush()
 
+            handicap = row[2]
+            komi = 0.5 if handicap else 7.5
             yield GameRecord(
-                row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9]
+                row[0], row[1], handicap, komi, row[4], row[5], row[6], row[7], row[8], row[9],
             )
 
         if not self.quiet:

--- a/analysis/util/AGAGameData.py
+++ b/analysis/util/AGAGameData.py
@@ -70,9 +70,11 @@ class AGAGameData:
                 sys.stdout.flush()
 
             handicap = row[2]
+            rules = "aga"
             komi = 0.5 if handicap else 7.5
             yield GameRecord(
                 row[0], row[1], handicap, komi, row[4], row[5], row[6], row[7], row[8], row[9],
+                rules,
             )
 
         if not self.quiet:

--- a/analysis/util/AGAGameData.py
+++ b/analysis/util/AGAGameData.py
@@ -71,7 +71,7 @@ class AGAGameData:
 
             handicap = row[2]
             rules = "aga"
-            komi = 0.5 if handicap else 7.5
+            komi = 0.5 if int(handicap) else 7.5
             yield GameRecord(
                 row[0], row[1], handicap, komi, row[4], row[5], row[6], row[7], row[8], row[9],
                 rules,

--- a/analysis/util/EGFGameData.py
+++ b/analysis/util/EGFGameData.py
@@ -73,7 +73,7 @@ class EGFGameData:
 
             handicap = row[2]
             rules = "japanese", # best guess
-            komi = 0.5 if handicap else 6.5
+            komi = 0.5 if int(handicap) else 6.5
             yield GameRecord(
                 row[0], row[1], handicap, komi, row[4], row[5], row[6], row[7], row[8], row[9],
                 rules,

--- a/analysis/util/EGFGameData.py
+++ b/analysis/util/EGFGameData.py
@@ -72,9 +72,12 @@ class EGFGameData:
                 sys.stdout.flush()
 
             handicap = row[2]
+            rules = "japanese", # best guess
             komi = 0.5 if handicap else 6.5
             yield GameRecord(
-                row[0], row[1], handicap, komi, row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11],
+                row[0], row[1], handicap, komi, row[4], row[5], row[6], row[7], row[8], row[9],
+                rules,
+                row[10], row[11],
             )
 
         if not self.quiet:

--- a/analysis/util/EGFGameData.py
+++ b/analysis/util/EGFGameData.py
@@ -71,8 +71,10 @@ class EGFGameData:
                 )
                 sys.stdout.flush()
 
+            handicap = row[2]
+            komi = 0.5 if handicap else 6.5
             yield GameRecord(
-                row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11],
+                row[0], row[1], handicap, komi, row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11],
             )
 
         if not self.quiet:

--- a/analysis/util/OGSGameData.py
+++ b/analysis/util/OGSGameData.py
@@ -107,8 +107,11 @@ class OGSGameData:
                 )
                 sys.stdout.flush()
 
+            # Hardcode for now.
+            rules = "japanese"
             yield GameRecord(
                 row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
+                rules,
             )
 
         if not self.quiet:

--- a/analysis/util/OGSGameData.py
+++ b/analysis/util/OGSGameData.py
@@ -86,7 +86,8 @@ class OGSGameData:
                     time_per_move,
                     timeout,
                     winner_id,
-                    ended
+                    ended,
+                    rules
                 FROM
                     game_records
                 %s
@@ -107,8 +108,21 @@ class OGSGameData:
                 )
                 sys.stdout.flush()
 
-            # Hardcode for now.
-            rules = "japanese"
+            # Clean the rules field.
+            if row[10] in ["aga", "chinese", "ing", "japanese", "korean", "nz"]:
+                rules = row[10]
+            elif row[10] == "Japanese":
+                rules = "japanese"
+            elif row[10] == "age":
+                rules = "aga"
+            elif row[10] == "ing sst":
+                rules = "ing"
+            elif row[10] == "ogs":
+                rules = "japanese"
+            else:
+                # Report new, unknown, rules spellings so we can clean them properly.
+                raise Exception("Unknown rules: '" + row[10] + "'")
+
             yield GameRecord(
                 row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
                 rules,

--- a/goratings/interfaces/GameRecord.py
+++ b/goratings/interfaces/GameRecord.py
@@ -14,6 +14,7 @@ class GameRecord:
     timeout: bool
     winner_id: int
     ended: int  # timestamp, seconds since epoch
+    rules: str
     black_manual_rank_update: Optional[int]  #
     white_manual_rank_update: Optional[int]  #
 
@@ -29,6 +30,7 @@ class GameRecord:
         timeout: bool,
         winner_id: int,
         ended: int,
+        rules: str,
         black_manual_rank_update: Optional[int] = None,
         white_manual_rank_update: Optional[int] = None,
     ):
@@ -42,6 +44,7 @@ class GameRecord:
         self.timeout = timeout
         self.winner_id = winner_id
         self.ended = ended
+        self.rules = rules
         self.black_manual_rank_update = black_manual_rank_update
         self.white_manual_rank_update = white_manual_rank_update
 


### PR DESCRIPTION
Neither AGA nor EGF games have komi in their databases, so we're just filling with 0 in the `SELECT` command.

Instead, pick some reasonable values:

- Assume AGA games use AGA rules, with komi 7.5 for even games. Set komi to 0.5 for handicap games, matching OGS data by NOT including the area bonus in the komi field.
- Assume EGF games use Japanese rules, with komi 6.5 for even and 0.5 for handicap.