### PR TITLE
Centralize skipping logic in analysis.util.SkipLogic

### DIFF
--- a/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
+++ b/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
@@ -9,6 +9,7 @@ from analysis.util import (
     config,
     get_handicap_adjustment,
     rating_to_rank,
+    should_skip_game,
 )
 from goratings.interfaces import GameRecord, RatingSystem, Storage
 from goratings.math.glicko2 import Glicko2Entry, glicko2_update
@@ -25,16 +26,8 @@ class DailyWindows(RatingSystem):
         self._storage = storage
 
     def process_game(self, game: GameRecord) -> Glicko2Analytics:
-        ## Only count the first timeout in correspondence games as a ranked loss
-        if game.timeout and game.speed == 3: # correspondence timeout
-            player_that_timed_out = game.black_id if game.black_id != game.winner_id else game.white_id
-            skip = self._storage.get_timeout_flag(game.black_id) or self._storage.get_timeout_flag(game.white_id)
-            self._storage.set_timeout_flag(player_that_timed_out, True)
-            if skip:
-                return Glicko2Analytics(skipped=True, game=game)
-        if game.speed == 3: # clear corr. timeout flags
-            self._storage.set_timeout_flag(game.black_id, True)
-            self._storage.set_timeout_flag(game.white_id, True)
+        if should_skip_game(game, self._storage):
+            return Glicko2Analytics(skipped=True, game=game)
 
         ## read base rating (last rating before the current rating period)
         window = (int(game.ended) // window_width) * window_width

--- a/analysis/analyze_gor.py
+++ b/analysis/analyze_gor.py
@@ -29,12 +29,12 @@ class OneGameAtATime(RatingSystem):
 
     def process_game(self, game: GameRecord) -> GorAnalytics:
         if game.black_manual_rank_update is not None:
-            storage.clear_set_count(game.black_id)
-            storage.set(game.black_id, GorEntry(rank_to_rating(game.black_manual_rank_update)))
+            self._storage.clear_set_count(game.black_id)
+            self._storage.set(game.black_id, GorEntry(rank_to_rating(game.black_manual_rank_update)))
 
         if game.white_manual_rank_update is not None:
-            storage.clear_set_count(game.white_id)
-            storage.set(game.white_id, GorEntry(rank_to_rating(game.white_manual_rank_update)))
+            self._storage.clear_set_count(game.white_id)
+            self._storage.set(game.white_id, GorEntry(rank_to_rating(game.white_manual_rank_update)))
 
         if should_skip_game(game, self._storage):
             return GorAnalytics(skipped=True, game=game)

--- a/analysis/analyze_gor.py
+++ b/analysis/analyze_gor.py
@@ -11,6 +11,7 @@ from analysis.util import (
     get_handicap_adjustment,
     rating_to_rank,
     rank_to_rating,
+    should_skip_game,
 )
 from goratings.interfaces import GameRecord, RatingSystem, Storage
 from goratings.math.gor import GorEntry, gor_update
@@ -28,24 +29,15 @@ class OneGameAtATime(RatingSystem):
 
     def process_game(self, game: GameRecord) -> GorAnalytics:
         if game.black_manual_rank_update is not None:
-            self._storage.clear_set_count(game.black_id)
-            self._storage.set(game.black_id, GorEntry(rank_to_rating(game.black_manual_rank_update)))
+            storage.clear_set_count(game.black_id)
+            storage.set(game.black_id, GorEntry(rank_to_rating(game.black_manual_rank_update)))
 
         if game.white_manual_rank_update is not None:
-            self._storage.clear_set_count(game.white_id)
-            self._storage.set(game.white_id, GorEntry(rank_to_rating(game.white_manual_rank_update)))
+            storage.clear_set_count(game.white_id)
+            storage.set(game.white_id, GorEntry(rank_to_rating(game.white_manual_rank_update)))
 
-        ## Only count the first timeout in correspondence games as a ranked loss
-        if game.timeout and game.speed == 3: # correspondence timeout
-            player_that_timed_out = game.black_id if game.black_id != game.winner_id else game.white_id
-            skip = self._storage.get_timeout_flag(game.black_id) or self._storage.get_timeout_flag(game.white_id)
-            self._storage.set_timeout_flag(player_that_timed_out, True)
-            if skip:
-                return GorAnalytics(skipped=True, game=game)
-        if game.speed == 3: # clear corr. timeout flags
-            self._storage.set_timeout_flag(game.black_id, True)
-            self._storage.set_timeout_flag(game.white_id, True)
-
+        if should_skip_game(game, self._storage):
+            return GorAnalytics(skipped=True, game=game)
 
         black = self._storage.get(game.black_id)
         white = self._storage.get(game.white_id)

--- a/analysis/util/SkipLogic.py
+++ b/analysis/util/SkipLogic.py
@@ -1,0 +1,23 @@
+from goratings.interfaces import (
+    GameRecord,
+    Storage,
+)
+
+__all__ = [
+    "should_skip_game",
+]
+
+def should_skip_game(game: GameRecord, storage: Storage) -> bool:
+    ## Only count the first timeout in correspondence games as a ranked loss
+    if game.timeout and game.speed == 3: # correspondence timeout
+        player_that_timed_out = game.black_id if game.black_id != game.winner_id else game.white_id
+        other_player = game.black_id if game.black_id == game.winner_id else game.white_id
+        skip = storage.get_timeout_flag(game.black_id) or self._storage.get_timeout_flag(game.white_id)
+        storage.set_timeout_flag(player_that_timed_out, True)
+        storage.set_timeout_flag(other_player, False)
+        if skip:
+            return True
+    elif game.speed == 3: # correspondence non timeout, clear flags for both
+        storage.set_timeout_flag(game.black_id, False)
+        storage.set_timeout_flag(game.white_id, False)
+    return False

--- a/analysis/util/SkipLogic.py
+++ b/analysis/util/SkipLogic.py
@@ -12,7 +12,7 @@ def should_skip_game(game: GameRecord, storage: Storage) -> bool:
     if game.timeout and game.speed == 3: # correspondence timeout
         player_that_timed_out = game.black_id if game.black_id != game.winner_id else game.white_id
         other_player = game.black_id if game.black_id == game.winner_id else game.white_id
-        skip = storage.get_timeout_flag(game.black_id) or self._storage.get_timeout_flag(game.white_id)
+        skip = storage.get_timeout_flag(game.black_id) or storage.get_timeout_flag(game.white_id)
         storage.set_timeout_flag(player_that_timed_out, True)
         storage.set_timeout_flag(other_player, False)
         if skip:

--- a/analysis/util/__init__.py
+++ b/analysis/util/__init__.py
@@ -7,6 +7,7 @@ from .GorAnalytics import GorAnalytics
 from .InMemoryStorage import InMemoryStorage
 from .OGSGameData import OGSGameData
 from .RatingMath import get_handicap_adjustment, rank_to_rating, rating_to_rank, set_optimizer_rating_points, set_exhaustive_log_parameters
+from .SkipLogic import should_skip_game
 from .TallyGameAnalytics import TallyGameAnalytics, num2rank
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "rating_to_rank",
     "rank_to_rating",
     "get_handicap_adjustment",
+    "should_skip_game",
     "configure_rating_to_rank",
     "num2rank",
     "set_optimizer_rating_points",


### PR DESCRIPTION
The skipping logic is duplicated across analysis scripts. It also seems a bit stale outside of `./analysis/analyze_glicko2_one_game_at_a_time.py`. Centralize it into a new helper utility.

This is mainly so that #46 can extend it without duplicating more code.