### PR TITLE
Add --handicap-rank-difference-{small,19x19} options

### DIFF
--- a/analysis/analyze_glicko2_daily_windows.py
+++ b/analysis/analyze_glicko2_daily_windows.py
@@ -45,7 +45,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id  else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.black_id  else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == game.black_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -58,7 +60,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == game.white_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -76,7 +80,9 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black_cur.rating,
             white_rating=white_cur.rating,

--- a/analysis/analyze_glicko2_glickman_weekly_window.py
+++ b/analysis/analyze_glicko2_glickman_weekly_window.py
@@ -53,7 +53,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.black_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -66,7 +68,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.white_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -84,7 +88,9 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black_cur.rating,
             white_rating=white_cur.rating,

--- a/analysis/analyze_glicko2_one_game_at_a_time.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time.py
@@ -35,12 +35,14 @@ class OneGameAtATime(RatingSystem):
         black = self._storage.get(game.black_id)
         white = self._storage.get(game.white_id)
 
-
         updated_black = glicko2_update(
             black,
             [
                 (
-                    white.copy(-get_handicap_adjustment(white.rating, game.handicap)),
+                    white.copy(-get_handicap_adjustment(white.rating, game.handicap,
+                                                        komi=game.komi, size=game.size,
+                                                        rules=game.rules,
+                            )),
                     game.winner_id == game.black_id,
                 )
             ],
@@ -50,7 +52,10 @@ class OneGameAtATime(RatingSystem):
             white,
             [
                 (
-                    black.copy(get_handicap_adjustment(black.rating, game.handicap)),
+                    black.copy(get_handicap_adjustment(black.rating, game.handicap,
+                                                       komi=game.komi, size=game.size,
+                                                       rules=game.rules,
+                            )),
                     game.winner_id == game.white_id,
                 )
             ],
@@ -65,7 +70,10 @@ class OneGameAtATime(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black.expected_win_probability(
-                white, get_handicap_adjustment(black.rating, game.handicap), ignore_g=True
+                white, get_handicap_adjustment(black.rating, game.handicap,
+                                               komi=game.komi, size=game.size,
+                                               rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black.rating,
             white_rating=white.rating,

--- a/analysis/analyze_glicko2_one_game_at_a_time_rating_grid.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time_rating_grid.py
@@ -63,7 +63,9 @@ class OneGameAtATimeRatingGrid(RatingSystem):
                     black,
                     [
                         (
-                            src_white.copy(-get_handicap_adjustment(src_white.rating, game.handicap)),
+                            src_white.copy(-get_handicap_adjustment(src_white.rating, game.handicap,
+                                    komi=game.komi, size=game.size, rules=game.rules,
+                                    )),
                             game.winner_id == game.black_id,
                         )
                     ],
@@ -73,7 +75,9 @@ class OneGameAtATimeRatingGrid(RatingSystem):
                     white,
                     [
                         (
-                            src_black.copy(get_handicap_adjustment(src_black.rating, game.handicap)),
+                            src_black.copy(get_handicap_adjustment(src_black.rating, game.handicap,
+                                    komi=game.komi, size=game.size, rules=game.rules,
+                                    )),
                             game.winner_id == game.white_id,
                         )
                     ],
@@ -89,7 +93,9 @@ class OneGameAtATimeRatingGrid(RatingSystem):
                     skipped=False,
                     game=game,
                     expected_win_rate=black.expected_win_probability(
-                        white, get_handicap_adjustment(black.rating, game.handicap), ignore_g=True
+                        white, get_handicap_adjustment(black.rating, game.handicap,
+                            komi=game.komi, size=game.size, rules=game.rules,
+                            ), ignore_g=True
                     ),
                     black_rating=black.rating,
                     white_rating=white.rating,

--- a/analysis/analyze_glicko2_weekly_window_no_unxepected_changes.py
+++ b/analysis/analyze_glicko2_weekly_window_no_unxepected_changes.py
@@ -50,7 +50,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.black_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -63,7 +65,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.white_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -96,7 +100,9 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black_cur.rating,
             white_rating=white_cur.rating,

--- a/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
+++ b/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
@@ -55,7 +55,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.black_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -68,7 +70,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap)),
+                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                            komi=past_game.komi, size=past_game.size, rules=past_game.rules,
+                            )),
                     past_game.winner_id == past_game.white_id
                 )
                 for past_game, opponent in self._storage.get_matches_newer_or_equal_to(
@@ -112,7 +116,9 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap), ignore_g=True
+                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    ), ignore_g=True
             ),
             black_rating=black_cur.rating,
             white_rating=white_cur.rating,

--- a/analysis/analyze_gor.py
+++ b/analysis/analyze_gor.py
@@ -44,15 +44,19 @@ class OneGameAtATime(RatingSystem):
 
 
         updated_black = gor_update(
-            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap)),
-            #white.with_handicap(-get_handicap_adjustment(white.rating, game.handicap)),
+            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    )),
+            #white.with_handicap(-get_handicap_adjustment(white.rating, game.handicap, ...)),
             white,
             1 if game.winner_id == game.black_id else 0,
         )
 
         updated_white = gor_update(
             white,
-            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap)),
+            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    )),
             1 if game.winner_id == game.white_id else 0,
         )
 
@@ -65,8 +69,10 @@ class OneGameAtATime(RatingSystem):
         return GorAnalytics(
             skipped=False,
             game=game,
-            expected_win_rate=black.with_handicap(get_handicap_adjustment(white.rating, game.handicap)).expected_win_probability(
-                #white.copy(-get_handicap_adjustment(white.rating, game.handicap))
+            expected_win_rate=black.with_handicap(get_handicap_adjustment(white.rating, game.handicap,
+                    komi=game.komi, size=game.size, rules=game.rules,
+                    )).expected_win_probability(
+                #white.copy(-get_handicap_adjustment(white.rating, game.handicap, ...))
                 white
             ),
             black_rating=black.rating,


### PR DESCRIPTION
Add options to compute the effective handicap rank difference, incorporating board size, komi, and the point value of handicap stones.

This hits a math domain error when tallying because the head start for black is sometimes enormous, such as 8 stones on a 9x9 board.

```
Processing OGS data
   2,739,321 /   30,811,698 games processed.  192.3s remainingTraceback (most recent call last):
  File "/Users/dexonsmith/Repos/online-go/goratings/analysis/analyze_glicko2_one_game_at_a_time.py", line 99, in <module>
    tally.add_glicko2_analytics(analytics)
  File "/Users/dexonsmith/Repos/online-go/goratings/analysis/util/TallyGameAnalytics.py", line 102, in add_glicko2_analytics
    self.prediction_cost[size][speed][rank][handicap] += - math.log(result.expected_win_rate if black_won else 1 - result.expected_win_rate)
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: math domain error
```

Since the options are off-by-default, it'd fine to land as-is and then decide what to do. Or we could fix first.

Here are the choices for what to do (either before or after this lands):

- Update the tallying code to check for 0 before calling `math.log()`.
- Clamp effective rank between (e.g.) 40kyu and 15dan
- Stop rating games with a handicap rank difference bigger than (e.g.) 9
- Some combination above the above.

Relates to #45. Replaces #46.