### PR TITLE
Add --games-offset to skip over initial game records

### DIFF
--- a/analysis/util/AGAGameData.py
+++ b/analysis/util/AGAGameData.py
@@ -25,6 +25,7 @@ class AGAGameData:
     def __iter__(self) -> Iterator[GameRecord]:
         c = self._conn.cursor()
         limit = config.args.num_games or 99999999999
+        offset = config.args.games_offset
         t = 0.0
         ct = 0
         num_records = 0
@@ -35,6 +36,10 @@ class AGAGameData:
             """
         ):
             num_records = int(row[0])
+            if offset > num_records:
+                num_records = 0
+            else:
+                num_records = num_records - offset
             if limit < num_records:
                 num_records = limit
 
@@ -56,8 +61,10 @@ class AGAGameData:
                     game_records ORDER BY ended
                 LIMIT
                     ?
+                OFFSET
+                    ?
             """,
-            [limit],
+            (limit, offset),
         ):
             ct += 1
             if not self.quiet and time() - t > 0.05:

--- a/analysis/util/EGFGameData.py
+++ b/analysis/util/EGFGameData.py
@@ -25,6 +25,7 @@ class EGFGameData:
     def __iter__(self) -> Iterator[GameRecord]:
         c = self._conn.cursor()
         limit = config.args.num_games or 99999999999
+        offset = config.args.games_offset
         t = 0.0
         ct = 0
         num_records = 0
@@ -35,6 +36,10 @@ class EGFGameData:
             """
         ):
             num_records = int(row[0])
+            if offset > num_records:
+                num_records = 0
+            else:
+                num_records = num_records - offset
             if limit < num_records:
                 num_records = limit
 
@@ -58,8 +63,10 @@ class EGFGameData:
                     game_records ORDER BY ended
                 LIMIT
                     ?
+                OFFSET
+                    ?
             """,
-            [limit],
+            (limit, offset),
         ):
             ct += 1
             if not self.quiet and time() - t > 0.05:

--- a/analysis/util/GameData.py
+++ b/analysis/util/GameData.py
@@ -32,6 +32,11 @@ cli.add_argument(
 )
 
 cli.add_argument(
+    "--games-offset", dest="games_offset", type=int, default=0,
+    help="Number of early games to skip before processing, 0 for none",
+)
+
+cli.add_argument(
     "--corr", dest="corr", const=1, default=False, action="store_const", help="Only use correspondence games",
 )
 

--- a/analysis/util/OGSGameData.py
+++ b/analysis/util/OGSGameData.py
@@ -29,6 +29,7 @@ class OGSGameData:
     def __iter__(self) -> Iterator[GameRecord]:
         c = self._conn.cursor()
         limit = config.args.num_games or 99999999999
+        offset = config.args.games_offset
         t = 0.0
         ct = 0
         num_records = 0
@@ -52,6 +53,10 @@ class OGSGameData:
             """ % where
         ):
             num_records = int(row[0])
+            if offset > num_records:
+                num_records = 0
+            else:
+                num_records = num_records - offset
             if limit < num_records:
                 num_records = limit
 
@@ -95,8 +100,10 @@ class OGSGameData:
                 ORDER BY ended
                 LIMIT
                     ?
+                OFFSET
+                    ?
             """ % (join, where),
-            [limit],
+            (limit, offset),
         ):
             ct += 1
             if not self.quiet and time() - t > 0.05:


### PR DESCRIPTION
Add `--games-offset` to skip over the given number of game records before starting, as companion option for `--games`.

E.g.:

- `--games=1000` looks at games 1 to 1000.
- `--games=1000 --games-offset=1000` looks at games 1001 to 2000.
- `--games=1000 --games-offset=2000` looks at games 2001 to 3000.

Works by adding an `OFFSET` to the `LIMIT` clause in the SQL query.

Sadly, not quite as useful as I had hoped... perhaps a limitation of sqlite, but there's a long delay before processing starts if you say something like `--games-offset=290000000` (to look at the last 1000000 or so games in `--ogs`). But still submitting since it allows you to analyze a slice other than the initial games.