### PR TITLE
Use base-e (not 10) in expected_win_probability

### DIFF
--- a/goratings/math/glicko2.py
+++ b/goratings/math/glicko2.py
@@ -72,15 +72,9 @@ class Glicko2Entry:
                 return 1 / sqrt(1 + 3 * q ** 2 * (self.deviation ** 2) / pi ** 2)
 
         E = 1 / (
-            1
-            + (
-                10
-                ** (
-                    -g(sqrt(self.deviation ** 2 + white.deviation ** 2))
+            1 + exp(-g(sqrt(self.deviation ** 2 + white.deviation ** 2))
                     * (self.rating + handicap_adjustment - white.rating)
-                    / 400
-                )
-            )
+                    / 400)
         )
         return E
 

--- a/goratings/math/glicko2.py
+++ b/goratings/math/glicko2.py
@@ -61,21 +61,15 @@ class Glicko2Entry:
         return self
 
     def expected_win_probability(self, white: "Glicko2Entry", handicap_adjustment: float, ignore_g: bool = False) -> float:
-        # Implementation as defined by: http://www.glicko.net/glicko/glicko.pdf
-        q = 0.0057565
-
+        # Implementation extracted from glicko2_update below.
         if not ignore_g:
-            def g(rd: float) -> float:
+            def g() -> float:
                 return 1
         else:
-            def g(rd: float) -> float:
-                return 1 / sqrt(1 + 3 * q ** 2 * (self.deviation ** 2) / pi ** 2)
+            def g() -> float:
+                return 1 / sqrt(1 + (3 * white.phi ** 2) / (pi ** 2))
 
-        E = 1 / (
-            1 + exp(-g(sqrt(self.deviation ** 2 + white.deviation ** 2))
-                    * (self.rating + handicap_adjustment - white.rating)
-                    / 400)
-        )
+        E = 1 / (1 + exp(-g() * (self.rating + handicap_adjustment - white.rating) / GLICKO2_SCALE))
         return E
 
 


### PR DESCRIPTION
Change `expected_win_probability` to use base-e (instead of base-10), to match Glicko-2.  `v5_glicko2_update` was already (correctly) using base-e.

This follow-up to 87c3fa8fb4129bd6d70d2c2e635f6237b1f3f227 gets handles the math domain error from tallying results on large small board handicaps. The base-10 bug made the expected win rate 1.0 (100%).

Of course, it's still possible to skip large handicap games when tallying results... but no longer necessary.

Relates to #45.