### PR TITLE
Filter games based on rank difference

### DIFF
--- a/analysis/util/RatingMath.py
+++ b/analysis/util/RatingMath.py
@@ -8,6 +8,7 @@ __all__ = [
     "rank_to_rating",
     "rating_to_rank",
     "get_handicap_adjustment",
+    "get_handicap_rank_difference",
     "rating_config",
     "set_optimizer_rating_points",
     "set_exhaustive_log_parameters",

--- a/analysis/util/TallyGameAnalytics.py
+++ b/analysis/util/TallyGameAnalytics.py
@@ -17,7 +17,7 @@ from .GameData import datasets_used
 from .Glicko2Analytics import Glicko2Analytics
 from .GorAnalytics import GorAnalytics
 from .InMemoryStorage import InMemoryStorage
-from .RatingMath import rating_config, rating_to_rank
+from .RatingMath import rating_config, rating_to_rank, get_handicap_rank_difference
 from .EGFGameData import EGFGameData
 from .AGAGameData import AGAGameData
 
@@ -73,7 +73,11 @@ class TallyGameAnalytics:
             self.games_ignored += 1
             return
 
-        if abs(result.black_rank + result.game.handicap - result.white_rank) > 1:
+        handicap_rank_difference = get_handicap_rank_difference(handicap=result.game.handicap,
+                                                                size=result.game.size,
+                                                                komi=result.game.komi,
+                                                                rules=result.game.rules)
+        if abs(result.black_rank + handicap_rank_difference - result.white_rank) > 1:
             self.games_ignored += 1
             return
 
@@ -89,7 +93,7 @@ class TallyGameAnalytics:
                 ]:
                     for handicap in [ALL, result.game.handicap]:
                         if isinstance(rank, int) or isinstance(rank, str):  # this is just to make mypy happy
-                            if abs(result.black_rank + result.game.handicap - result.white_rank) <= 1:
+                            if abs(result.black_rank + handicap_rank_difference - result.white_rank) <= 1:
                                 self.count_black_wins[size][speed][rank][handicap] += 1
                                 if black_won:
                                     self.black_wins[size][speed][rank][handicap] += 1

--- a/analysis/util/__init__.py
+++ b/analysis/util/__init__.py
@@ -6,7 +6,7 @@ from .Glicko2Analytics import Glicko2Analytics
 from .GorAnalytics import GorAnalytics
 from .InMemoryStorage import InMemoryStorage
 from .OGSGameData import OGSGameData
-from .RatingMath import get_handicap_adjustment, rank_to_rating, rating_to_rank, set_optimizer_rating_points, set_exhaustive_log_parameters
+from .RatingMath import get_handicap_adjustment, get_handicap_rank_difference, rank_to_rating, rating_to_rank, set_optimizer_rating_points, set_exhaustive_log_parameters
 from .SkipLogic import should_skip_game
 from .TallyGameAnalytics import TallyGameAnalytics, num2rank
 
@@ -24,6 +24,7 @@ __all__ = [
     "rating_to_rank",
     "rank_to_rating",
     "get_handicap_adjustment",
+    "get_handicap_rank_difference",
     "should_skip_game",
     "configure_rating_to_rank",
     "num2rank",


### PR DESCRIPTION
- Filter games to tally based on handicap rank difference, instead of raw handicap.
- Add `--mismatch-threshold-{black-wins,predictions}` to allow threshold to be configured command-line.

Relates to #45.