### PR TITLE
Fix white handicap adjustment by moving the +/- to the "rank" domain

### DIFF
--- a/analysis/analyze_glicko2_daily_windows.py
+++ b/analysis/analyze_glicko2_daily_windows.py
@@ -45,7 +45,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id  else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                    opponent.copy(get_handicap_adjustment(
+                            "black" if past_game.black_id != game.black_id else "white",
+                            opponent.rating, past_game.handicap,
                             komi=past_game.komi, size=past_game.size, rules=past_game.rules,
                             )),
                     past_game.winner_id == game.black_id
@@ -60,7 +62,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                    opponent.copy(get_handicap_adjustment(
+                            "black" if past_game.black_id != game.black_id else "white",
+                            opponent.rating, past_game.handicap,
                             komi=past_game.komi, size=past_game.size, rules=past_game.rules,
                             )),
                     past_game.winner_id == game.white_id
@@ -80,7 +84,7 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                white_cur, get_handicap_adjustment("black", black_cur.rating, game.handicap,
                     komi=game.komi, size=game.size, rules=game.rules,
                     ), ignore_g=True
             ),

--- a/analysis/analyze_glicko2_glickman_weekly_window.py
+++ b/analysis/analyze_glicko2_glickman_weekly_window.py
@@ -53,7 +53,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                    opponent.copy(get_handicap_adjustment(
+                            "black" if past_game.black_id != game.black_id else "white",
+                            opponent.rating, past_game.handicap,
                             komi=past_game.komi, size=past_game.size, rules=past_game.rules,
                             )),
                     past_game.winner_id == past_game.black_id
@@ -68,7 +70,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                    opponent.copy(get_handicap_adjustment(
+                            "black" if past_game.black_id != game.black_id else "white",
+                            opponent.rating, past_game.handicap,
                             komi=past_game.komi, size=past_game.size, rules=past_game.rules,
                             )),
                     past_game.winner_id == past_game.white_id
@@ -88,7 +92,7 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                white_cur, get_handicap_adjustment("black", black_cur.rating, game.handicap,
                     komi=game.komi, size=game.size, rules=game.rules,
                     ), ignore_g=True
             ),

--- a/analysis/analyze_glicko2_one_game_at_a_time.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time.py
@@ -39,7 +39,7 @@ class OneGameAtATime(RatingSystem):
             black,
             [
                 (
-                    white.copy(-get_handicap_adjustment(white.rating, game.handicap,
+                    white.copy(get_handicap_adjustment("white", white.rating, game.handicap,
                                                         komi=game.komi, size=game.size,
                                                         rules=game.rules,
                             )),
@@ -52,7 +52,7 @@ class OneGameAtATime(RatingSystem):
             white,
             [
                 (
-                    black.copy(get_handicap_adjustment(black.rating, game.handicap,
+                    black.copy(get_handicap_adjustment("black", black.rating, game.handicap,
                                                        komi=game.komi, size=game.size,
                                                        rules=game.rules,
                             )),
@@ -70,7 +70,7 @@ class OneGameAtATime(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black.expected_win_probability(
-                white, get_handicap_adjustment(black.rating, game.handicap,
+                white, get_handicap_adjustment("black", black.rating, game.handicap,
                                                komi=game.komi, size=game.size,
                                                rules=game.rules,
                     ), ignore_g=True

--- a/analysis/analyze_glicko2_one_game_at_a_time_rating_grid.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time_rating_grid.py
@@ -63,7 +63,7 @@ class OneGameAtATimeRatingGrid(RatingSystem):
                     black,
                     [
                         (
-                            src_white.copy(-get_handicap_adjustment(src_white.rating, game.handicap,
+                            src_white.copy(get_handicap_adjustment("white", src_white.rating, game.handicap,
                                     komi=game.komi, size=game.size, rules=game.rules,
                                     )),
                             game.winner_id == game.black_id,
@@ -75,7 +75,7 @@ class OneGameAtATimeRatingGrid(RatingSystem):
                     white,
                     [
                         (
-                            src_black.copy(get_handicap_adjustment(src_black.rating, game.handicap,
+                            src_black.copy(get_handicap_adjustment("black", src_black.rating, game.handicap,
                                     komi=game.komi, size=game.size, rules=game.rules,
                                     )),
                             game.winner_id == game.white_id,
@@ -93,7 +93,7 @@ class OneGameAtATimeRatingGrid(RatingSystem):
                     skipped=False,
                     game=game,
                     expected_win_rate=black.expected_win_probability(
-                        white, get_handicap_adjustment(black.rating, game.handicap,
+                        white, get_handicap_adjustment("black", black.rating, game.handicap,
                             komi=game.komi, size=game.size, rules=game.rules,
                             ), ignore_g=True
                     ),

--- a/analysis/analyze_glicko2_weekly_window_no_unxepected_changes.py
+++ b/analysis/analyze_glicko2_weekly_window_no_unxepected_changes.py
@@ -50,7 +50,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                    opponent.copy(get_handicap_adjustment(
+                            "black" if past_game.black_id != game.black_id else "white",
+                            opponent.rating, past_game.handicap,
                             komi=past_game.komi, size=past_game.size, rules=past_game.rules,
                             )),
                     past_game.winner_id == past_game.black_id
@@ -65,7 +67,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                    opponent.copy(get_handicap_adjustment(
+                            "black" if past_game.black_id != game.black_id else "white",
+                            opponent.rating, past_game.handicap,
                             komi=past_game.komi, size=past_game.size, rules=past_game.rules,
                             )),
                     past_game.winner_id == past_game.white_id
@@ -100,7 +104,7 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                white_cur, get_handicap_adjustment("black", black_cur.rating, game.handicap,
                     komi=game.komi, size=game.size, rules=game.rules,
                     ), ignore_g=True
             ),

--- a/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
+++ b/analysis/analyze_glicko2_weekly_window_reduce_rating_movement.py
@@ -55,7 +55,9 @@ class DailyWindows(RatingSystem):
             black_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.black_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                    opponent.copy(get_handicap_adjustment(
+                            "black" if past_game.black_id != game.black_id else "white",
+                            opponent.rating, past_game.handicap,
                             komi=past_game.komi, size=past_game.size, rules=past_game.rules,
                             )),
                     past_game.winner_id == past_game.black_id
@@ -70,7 +72,9 @@ class DailyWindows(RatingSystem):
             white_base,
             [
                 (
-                    opponent.copy((1 if past_game.black_id != game.white_id else -1) * get_handicap_adjustment(opponent.rating, past_game.handicap,
+                    opponent.copy(get_handicap_adjustment(
+                            "black" if past_game.black_id != game.black_id else "white",
+                            opponent.rating, past_game.handicap,
                             komi=past_game.komi, size=past_game.size, rules=past_game.rules,
                             )),
                     past_game.winner_id == past_game.white_id
@@ -116,7 +120,7 @@ class DailyWindows(RatingSystem):
             skipped=False,
             game=game,
             expected_win_rate=black_cur.expected_win_probability(
-                white_cur, get_handicap_adjustment(black_cur.rating, game.handicap,
+                white_cur, get_handicap_adjustment("black", black_cur.rating, game.handicap,
                     komi=game.komi, size=game.size, rules=game.rules,
                     ), ignore_g=True
             ),

--- a/analysis/analyze_gor.py
+++ b/analysis/analyze_gor.py
@@ -44,17 +44,16 @@ class OneGameAtATime(RatingSystem):
 
 
         updated_black = gor_update(
-            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap,
+            black.with_handicap(get_handicap_adjustment("black", black.rating, game.handicap,
                     komi=game.komi, size=game.size, rules=game.rules,
                     )),
-            #white.with_handicap(-get_handicap_adjustment(white.rating, game.handicap, ...)),
             white,
             1 if game.winner_id == game.black_id else 0,
         )
 
         updated_white = gor_update(
             white,
-            black.with_handicap(get_handicap_adjustment(black.rating, game.handicap,
+            black.with_handicap(get_handicap_adjustment("black", black.rating, game.handicap,
                     komi=game.komi, size=game.size, rules=game.rules,
                     )),
             1 if game.winner_id == game.white_id else 0,
@@ -69,10 +68,9 @@ class OneGameAtATime(RatingSystem):
         return GorAnalytics(
             skipped=False,
             game=game,
-            expected_win_rate=black.with_handicap(get_handicap_adjustment(white.rating, game.handicap,
+            expected_win_rate=black.with_handicap(get_handicap_adjustment("black", black.rating, game.handicap,
                     komi=game.komi, size=game.size, rules=game.rules,
                     )).expected_win_probability(
-                #white.copy(-get_handicap_adjustment(white.rating, game.handicap, ...))
                 white
             ),
             black_rating=black.rating,

--- a/analysis/util/RatingMath.py
+++ b/analysis/util/RatingMath.py
@@ -144,9 +144,17 @@ def get_handicap_rank_difference(handicap: int, size: int, komi: float, rules: s
     return handicap
 
 
-def get_handicap_adjustment(rating: float, handicap: int, size: int, komi: float, rules: str) -> float:
+def get_handicap_adjustment(player: str, rating: float, handicap: int, size: int, komi: float, rules: str) -> float:
     rank_difference = get_handicap_rank_difference(handicap, size, komi, rules)
-    effective_rank = rating_to_rank(rating) + rank_difference
+
+    # Apply the +/- for white/black in the "rank" domain where it's symmetric.
+    # Note that the "rating" domain is log-scale, where +/- is asymmetric.
+    assert player == "white" or player == "black"
+    if player == "black":
+        effective_rank = rating_to_rank(rating) + rank_difference
+    else:
+        effective_rank = rating_to_rank(rating) - rank_difference
+
     return rank_to_rating(effective_rank) - rating
 
 
@@ -329,8 +337,9 @@ def configure_rating_to_rank(args: argparse.Namespace) -> None:
         raise NotImplementedError
 
     for size in [9, 13, 19]:
-        assert round(get_handicap_adjustment(1000.0, 0, size=size, rules="japanese", komi=6.5), 8) == 0
-        assert round(get_handicap_adjustment(1000.0, 0, size=size, rules="aga", komi=7.5), 8) == 0
+        for player in ["white", "black"]:
+            assert round(get_handicap_adjustment(player, 1000.0, 0, size=size, rules="japanese", komi=6.5), 8) == 0
+            assert round(get_handicap_adjustment(player, 1000.0, 0, size=size, rules="aga", komi=7.5), 8) == 0
 
 
 def lerp(x:float, y:float, a:float):


### PR DESCRIPTION
To update rating after a game result, we adjust the opponent's rating by adding or subtracting the effective handicap.

The code before this commit was correct for adjusting black's rating, but incorrect for adjusting white's rating:

- `get_handicap_adjustment` always behaved as-if adjusting black's rating, *adding* the effective handicap.
- The caller passed on `+difference` (black) or `-difference` (white).
    - `-difference` was too small when white's rating was >1500.
    - `-difference` was too big when white's rating was <1500.

With this patch, we do the +/- in the "rank" domain where the effective handicap is symmetric:

- `get_handicap_adjustment` now takes a "black"/"white" parameter so it knows which rating it is adjusting, and returns the correct difference.
- The caller passes on this (maybe negative) difference without inverting it.

As a drive-by, also updated `analysis/analyze_gor.py` to pass the correct parameters for the `expected_win_probability` calculation (now the parameters match the ratings adjustments higher in the same function).