### PR TITLE
Simplify expand_deviation_because_no_games_played by using the closed from

### DIFF
--- a/goratings/math/glicko2.py
+++ b/goratings/math/glicko2.py
@@ -53,10 +53,9 @@ class Glicko2Entry:
         global MAX_RD
         global MIN_RD
 
-        for _i in range(n_periods):
-            phi_prime = sqrt(self.phi ** 2 + self.volatility ** 2)
-            self.deviation = min(MAX_RD, max(MIN_RD, GLICKO2_SCALE * phi_prime))
-            self.phi = self.deviation / GLICKO2_SCALE
+        phi_prime = sqrt(self.phi ** 2 + n_periods * self.volatility ** 2)
+        self.deviation = min(MAX_RD, max(MIN_RD, GLICKO2_SCALE * phi_prime))
+        self.phi = self.deviation / GLICKO2_SCALE
 
         return self
 


### PR DESCRIPTION
`expand_deviation_because_no_games_played` is evaluating degradation of the deviation over time, evaluating a bunch of periods all at once.  It's doing the following:

    a1 = sqrt(a0^2 + b^2)
    a2 = sqrt(a1^2 + b^2)
    a3 = sqrt(a2^2 + b^2)
    ...
    aN = sqrt(a(N-1)^2 + b^2)

where:

- `a0` is the initial deviation,
- `b` is the volatility, and
- `aN` is the final deviation.

Squaring both sides of `aN` and substituting values from earlier iterations reveals a closed form:

    aN^2 = a(N-1)^2 + b^2
         = a(N-2)^2 + 2*b^2
         = a(N-3)^2 + 3*b^2
         = ...
         = a0^2 + N*b^2

Thus, we have:

    aN = sqrt(a0^2 + N*b^2)

Use that directly.