### PR TITLE
Add --aging-period to experiment with expanding deviation in stale ratings

### DIFF
--- a/analysis/analyze_glicko2_one_game_at_a_time.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time.py
@@ -15,7 +15,6 @@ from analysis.util import (
 from goratings.interfaces import GameRecord, RatingSystem, Storage
 from goratings.math.glicko2 import Glicko2Entry, glicko2_update
 
-
 class OneGameAtATime(RatingSystem):
     _storage: Storage
 
@@ -34,6 +33,9 @@ class OneGameAtATime(RatingSystem):
 
         black = self._storage.get(game.black_id)
         white = self._storage.get(game.white_id)
+        if config.args.aging_period:
+            black = black.after_aging(game.ended, period_duration=config.args.aging_period * 60 * 60 * 24)
+            white = white.after_aging(game.ended, period_duration=config.args.aging_period * 60 * 60 * 24)
 
         updated_black = glicko2_update(
             black,

--- a/analysis/util/Config.py
+++ b/analysis/util/Config.py
@@ -29,6 +29,10 @@ glicko2_config.add_argument("--min-rd", dest="min_rd", type=float, default=10.0,
 glicko2_config.add_argument(
     "--max-rd", dest="max_rd", type=float, default=500.0, help="maximum rating deviation",
 )
+glicko2_config.add_argument(
+    "--aging-period", dest="aging_period", type=float, default=0,
+    help="number of days in the aging period, or 0 to disable aging",
+)
 
 
 def configure_glicko2(args: argparse.Namespace) -> None:


### PR DESCRIPTION
New option `--aging-period` (a duration measured in days) makes ratings age continuously.  `--aging-period=0` (the default) turns it off.

E.g., setting `--aging-period=7` mimicks a window of one week, where the deviation for each rating is expanded according to the (fractional) number of weeks that have passed since the rating was established.

Currently only implemented in analysis/analyze_glicko2_one_game_at_a_time.py. I'll also add it to the ratings-grid script when I get that going again...

One thought: with this in place, I wonder if "step 6" should be skipped. I.e., 
```
    # step 6
    phi_star = sqrt(player.phi ** 2 + new_volatility ** 2)
```
is both (a) evaluated fully on every game and (b) continuously, averaging once per period (via `--aging-period`). Maybe the every-game evaluation should be skipped (and `phi_star = player.phi` instead inside `glicko2_update`). I'll experiment with that tomorrow/this week.