### PR TITLE
Re-implement aging period inside of glicko2_update

### DIFF
--- a/analysis/analyze_glicko2_one_game_at_a_time.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time.py
@@ -33,9 +33,6 @@ class OneGameAtATime(RatingSystem):
 
         black = self._storage.get(game.black_id)
         white = self._storage.get(game.white_id)
-        if config.args.aging_period:
-            black = black.after_aging(game.ended, period_duration=config.args.aging_period * 60 * 60 * 24)
-            white = white.after_aging(game.ended, period_duration=config.args.aging_period * 60 * 60 * 24)
 
         updated_black = glicko2_update(
             black,
@@ -48,6 +45,7 @@ class OneGameAtATime(RatingSystem):
                     game.winner_id == game.black_id,
                 )
             ],
+            timestamp=game.ended,
         )
 
         updated_white = glicko2_update(
@@ -61,6 +59,7 @@ class OneGameAtATime(RatingSystem):
                     game.winner_id == game.white_id,
                 )
             ],
+            timestamp=game.ended,
         )
 
         self._storage.set(game.black_id, updated_black)

--- a/analysis/util/Config.py
+++ b/analysis/util/Config.py
@@ -30,14 +30,19 @@ glicko2_config.add_argument(
     "--max-rd", dest="max_rd", type=float, default=500.0, help="maximum rating deviation",
 )
 glicko2_config.add_argument(
-    "--aging-period", dest="aging_period", type=float, default=0,
-    help="number of days in the aging period, or 0 to disable aging",
+    "--aging-period", dest="aging_period", type=float,
+    help="number of days in the aging period, or --no-aging-period to disable",
+)
+glicko2_config.add_argument(
+    "--no-aging-period", dest="aging_period", action='store_const', const=None,
+    help="turn off aging period",
 )
 
 
 def configure_glicko2(args: argparse.Namespace) -> None:
     glicko2_configure(
         tao=args.tao, min_rd=args.min_rd, max_rd=args.max_rd,
+        aging_period_days=args.aging_period,
     )
 
 


### PR DESCRIPTION
Re-implement `--aging-period` inside of `glicko2_update`:

- If there are no opponents, update deviation using current volatility.
- Update player and opponent deviations using old volatility, catching up to a timestamp that's one period old.
- Leave in the "full period" volatility update with the new volatility.

This refactor makes it easier to share the logic (whatever it is precisely) between analysis scripts, although I haven't updated the other scripts yet to pass in timestamps.