### PR TITLE
Add '--rating-history-db' to save ratings in a DB

### DIFF
--- a/analysis/analyze_glicko2_one_game_at_a_time.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time.py
@@ -64,8 +64,8 @@ class OneGameAtATime(RatingSystem):
 
         self._storage.set(game.black_id, updated_black)
         self._storage.set(game.white_id, updated_white)
-        #self._storage.add_rating_history(game.black_id, game.ended, updated_black)
-        #self._storage.add_rating_history(game.white_id, game.ended, updated_white)
+        self._storage.add_rating_history(game.black_id, game.ended, updated_black)
+        self._storage.add_rating_history(game.white_id, game.ended, updated_white)
 
         return Glicko2Analytics(
             skipped=False,
@@ -98,6 +98,8 @@ tally = TallyGameAnalytics(storage)
 for game in game_data:
     analytics = engine.process_game(game)
     tally.add_glicko2_analytics(analytics)
+
+storage.save_rating_history("overall")
 
 tally.print()
 


### PR DESCRIPTION
Add `--rating-history-db` command-line option to save ratings in an sqlite3 database.

This adds a method to InMemoryStorage to save the rating history. It takes a `category` string for future use with rating grids, where there's a different InMemoryStorage for each rating category, but for now only `OneGameAtATime` has been updated.

An aborted implementation used a new storage type OnDiskStorage instead of InMemoryStorage, but it was way too slow to build the table incrementally. Instead, this implementation writes the values in bulk at the end, using a generator expression to visit the rating history.