### PR TITLE
Detect starting ratings with an initial pass through data

### DIFF
--- a/analysis/analyze_glicko2_one_game_at_a_time.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time.py
@@ -99,9 +99,9 @@ def detect_starting_ratings(storage: InMemoryStorage):
 
     def parse_rank(rank: str) -> float:
         if rank[-1:] == "k":
-            return 30 - float(rank[:-1])
+            return 30 - float(int(rank[:-1]))
         if rank[-1:] == "d":
-            return 30 + float(rank[:-1]) - 1
+            return 30 + float(int(rank[:-1])) - 1
         raise ValueError("invalid rank")
 
     STARTING_RANK_DEVIATION = 250
@@ -109,16 +109,18 @@ def detect_starting_ratings(storage: InMemoryStorage):
     def make_starting_rating(rank: str) -> Glicko2Entry:
         rating = rank_to_rating(parse_rank(rank))
         return Glicko2Entry(rating=rating, deviation=STARTING_RANK_DEVIATION)
+    def make_rating_threshold(rank: str) -> float:
+        return rank_to_rating(parse_rank(rank))
 
     starting_rating_newtogo = make_starting_rating("25k")
     starting_rating_basic = make_starting_rating("22k")
     starting_rating_intermediate = make_starting_rating("12k")
     starting_rating_advanced = make_starting_rating("2k")
 
-    weaker_threshold_detect_newtogo = rank_to_rating(parse_rank("35k"))
-    weaker_threshold_detect_basic = rank_to_rating(parse_rank("20k"))
-    weaker_threshold_detect_intermediate = rank_to_rating(parse_rank("10k"))
-    stronger_threshold_detect_advanced = rank_to_rating(parse_rank("4k"))
+    weaker_threshold_detect_newtogo = make_rating_threshold("35k")
+    weaker_threshold_detect_basic = make_rating_threshold("20k")
+    weaker_threshold_detect_intermediate = make_rating_threshold("10k")
+    stronger_threshold_detect_advanced = make_rating_threshold("4k")
     def update_starting_rating(player: int, rating: float, deviation: float) -> None:
         # Ever worse than 35k? New to Go.
         if rating < weaker_threshold_detect_newtogo:

--- a/analysis/analyze_glicko2_one_game_at_a_time.py
+++ b/analysis/analyze_glicko2_one_game_at_a_time.py
@@ -92,18 +92,9 @@ cli.add_argument(
     help="Detect starting ratings by running analysis twice",
 )
 
-
-# Run
-config(cli.parse_args(), "glicko2-one-game-at-a-time")
-
-game_data = GameData()
-storage = InMemoryStorage(Glicko2Entry)
-engine = OneGameAtATime(storage)
-tally = TallyGameAnalytics(storage)
-
-if config.args.detect_starting_ratings:
+def detect_starting_ratings(storage: InMemoryStorage):
     detection_storage = InMemoryStorage(Glicko2Entry)
-    detection_engine = OneGameAtATime(storage)
+    detection_engine = OneGameAtATime(detection_storage)
     detection_data = GameData()
 
     def parse_rank(rank: str) -> float:
@@ -113,15 +104,16 @@ if config.args.detect_starting_ratings:
             return 30 + float(rank[:-1]) - 1
         raise ValueError("invalid rank")
 
-    starting_deviation = 250
-    def make_starting_rank(rank: str) -> Glicko2Entry:
+    STARTING_RANK_DEVIATION = 250
+    PROVISIONAL_RANK_CUTOFF = 160
+    def make_starting_rating(rank: str) -> Glicko2Entry:
         rating = rank_to_rating(parse_rank(rank))
-        return Glicko2Entry(rating=rating, deviation=starting_deviation)
+        return Glicko2Entry(rating=rating, deviation=STARTING_RANK_DEVIATION)
 
-    starting_rating_newtogo = make_starting_rank("25k")
-    starting_rating_basic = make_starting_rank("22k")
-    starting_rating_intermediate = make_starting_rank("12k")
-    starting_rating_advanced = make_starting_rank("2k")
+    starting_rating_newtogo = make_starting_rating("25k")
+    starting_rating_basic = make_starting_rating("22k")
+    starting_rating_intermediate = make_starting_rating("12k")
+    starting_rating_advanced = make_starting_rating("2k")
 
     weaker_threshold_detect_newtogo = rank_to_rating(parse_rank("35k"))
     weaker_threshold_detect_basic = rank_to_rating(parse_rank("20k"))
@@ -140,21 +132,33 @@ if config.args.detect_starting_ratings:
             return
 
         # First non-provisional rating is weaker than 10k. Intermediate.
-        if rating < weaker_threshold_detect_intermediate and deviation <= 140:
-            if storage.get(player).deviation > starting_deviation:
+        if rating < weaker_threshold_detect_intermediate and deviation <= PROVISIONAL_RANK_CUTOFF:
+            if storage.get(player).deviation > STARTING_RANK_DEVIATION:
                 storage.set(player, starting_rating_intermediate)
             return
 
         # First non-provisional rating is stronger than 4k. Advanced.
-        if rating > stronger_threshold_detect_advanced and deviation <= 140:
-            if storage.get(player).deviation > starting_deviation:
+        if rating > stronger_threshold_detect_advanced and deviation <= PROVISIONAL_RANK_CUTOFF:
+            if storage.get(player).deviation > STARTING_RANK_DEVIATION:
                 storage.set(player, starting_rating_advanced)
             return
 
-    for game in game_data:
+    for game in detection_data:
         result = detection_engine.process_game(game)
         update_starting_rating(result.game.black_id, result.black_rating, result.black_deviation)
         update_starting_rating(result.game.white_id, result.white_rating, result.white_deviation)
+
+
+# Run
+config(cli.parse_args(), "glicko2-one-game-at-a-time")
+
+game_data = GameData()
+storage = InMemoryStorage(Glicko2Entry)
+engine = OneGameAtATime(storage)
+tally = TallyGameAnalytics(storage)
+
+if config.args.detect_starting_ratings:
+    detect_starting_ratings(storage)
 
 for game in game_data:
     analytics = engine.process_game(game)


### PR DESCRIPTION
Add option `--detect-starting-ratings`, which does an initial pass through games and sets starting ratings in many cases.

Everything is just in the one-game-at-a-time data, and it's not at all configurable, but it at least allow some hardcoded experiments.

