### PR TITLE
Quality of life fix: to make Analysis scripts runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To do test runs you'll want to be editing and running files in the `analysis` di
 For example, this should work out of the box:
 
 ```
-analysis/analyze_glicko2_one_game_at_a_time.py
+pypy3 -m analysis.analyze_glicko2_one_game_at_a_time
 ```
 
 # Parameter tuning
@@ -54,3 +54,19 @@ analysis/analyze_glicko2_one_game_at_a_time.py
 The analysis scripts import some common utility code that includes some parameters
 to tune, such as the variables used in converting ratings to ranks, glicko2 variables,
 and that sort of thing. For a full up to date list, run an analysis script with `--help`
+
+# Requirements
+
+When running PyPy3, you might need to have some (or all) of the following dependencies, **before** pip installing moudules from requirements.txt:
+
+```
+brew install swig # Required for C/C++ extensions
+# if Scipy PyPy3 wheels are not available for your OS:
+brew install scipy
+# if pip stuggles with pygsl:
+brew install gsl
+```
+
+# Running in CPython 3.10-3.13+
+
+Certain scripts are not compatible with CPython due to stricter OverflowError handling (overflow of max python float value). This behaviour is currently known around `glicko2_update()` in Step 5 (root finding interation for sigma prime).

--- a/analysis/util/TallyGameAnalytics.py
+++ b/analysis/util/TallyGameAnalytics.py
@@ -358,7 +358,7 @@ class TallyGameAnalytics:
         if os.path.exists(pathname + 'self_reported_account_links.full.json'):
             pathname += 'self_reported_account_links.full.json'
         elif os.path.exists(pathname + 'self_reported_account_links.json'):
-            pathname = 'self_reported_account_links.json'
+            pathname += 'self_reported_account_links.json'
         else:
             raise Exception('Failed to find self_reported_account_links json file')
 
@@ -458,7 +458,7 @@ class TallyGameAnalytics:
         if os.path.exists(pathname + 'self_reported_account_links.full.json'):
             pathname += 'self_reported_account_links.full.json'
         elif os.path.exists(pathname + 'self_reported_account_links.json'):
-            pathname = 'self_reported_account_links.json'
+            pathname += 'self_reported_account_links.json'
         else:
             raise Exception('Failed to find self_reported_account_links json file')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ tox
 python-dateutil
 scipy
 numpy
-pygsl
+pygsl # Optional
 filelock
-python-dateutil


### PR DESCRIPTION
This is a quality of life update for main branch to make code runnable in PyPy3 3.10 .venv (at least on my machine)
- Fixed `analysis` module by adding`__init__.py` to run scripts
- Fixed broken JSON Paths in `TallyGameAnalytics.py`
- Removed a duplicate from requirements.txt

This ensures we can run analysis scripts in the latest PyPy

- TODO: I cant find stable Pygls or Scipy wheels for Pypy3.10 for my Mac M1 ARM64, so I brewed them as executables. Gls still didnt install properly but analysis code ?runs? without it..